### PR TITLE
Disable bad events

### DIFF
--- a/code/modules/events/anomaly_pyro.dm
+++ b/code/modules/events/anomaly_pyro.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/anomaly/anomaly_pyro
 	name = "Anomaly: Pyroclastic"
 	typepath = /datum/round_event/anomaly/anomaly_pyro
-
+	min_players = 20 //LunarStation Edit
 	max_occurrences = 5
 	weight = 20
 

--- a/code/modules/events/operative.dm
+++ b/code/modules/events/operative.dm
@@ -2,7 +2,7 @@
 	name = "Lone Operative"
 	typepath = /datum/round_event/ghost_role/operative
 	weight = 0 //Admin only
-	max_occurrences = 1
+	max_occurrences = 0 //Lunarstation Edit
 
 /datum/round_event/ghost_role/operative
 	minimum_required = 1

--- a/code/modules/events/supermatter_surge.dm
+++ b/code/modules/events/supermatter_surge.dm
@@ -2,7 +2,7 @@
 	name = "Supermatter Surge"
 	typepath = /datum/round_event/supermatter_surge
 	weight = 20
-	max_occurrences = 4
+	max_occurrences = 0 //Lunarstation Edit
 	earliest_start = 10 MINUTES
 
 /datum/round_event_control/supermatter_surge/canSpawnEvent()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Disabled supermatter surge

Disabled lone operative

Made minpop for pyro anomaly 20

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

One at a time.

Supermatter surge:
On first glance this seems a'ight, just makes engineers have to pay attention and go tweak the engine a bit when it surges. What's so bad about that? The answer is simple, it has a tendency to absolutely destroy more advanced engine setups with no way of preventing it. See exhibit A:
![image](https://user-images.githubusercontent.com/35672377/128468455-0cf02179-7899-4d5e-b64a-d823032a9cf9.png)

Several explosions happened seconds after the surge was announced, giving me absolutely no time to react whatsoever, and instantly resulting it what would have been a delam if I hadn't deleted the crystal, with pretty much no way of stopping it seen as the entire supermatter chamber was destroyed. This isn't fun or engaging, this is awful and annoying and discourages engineers from actually wanting to do these more advanced setups out of fear.

Lone operative:
Pretty self explanatory, we're not really looking to do antags, and this event has an annoying habit of triggering on extended rounds. This can still be spawned by admins, but it shouldn't trigger by itself.

Pyro Anomaly:
Pyro anomaly is pretty bad for lowpop. It spawns two fairly resilient slimes and makes a room entirely uninhabitable until engineering (if there even is engineering) begrudgingly comes over to fix the damage from the giant fire. Not cool and just shafts lowpop. Playercount of 20 feels more fair.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed Supermatter surge
del: Removed Lone Operative
tweak: Set minpop for Pyro anomaly to 20
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
